### PR TITLE
comparator test cases passed

### DIFF
--- a/QB_CoA_Lib/CoAComparator.cs
+++ b/QB_CoA_Lib/CoAComparator.cs
@@ -7,7 +7,7 @@ namespace QB_CoA_Lib
     {
         public static List<ChartOfAccount> CompareAccounts(List<ChartOfAccount> companyAccounts)
         {
-            Log.Information("CoAComparator Initialized.");
+            Log.Information("ChartOfAccountComparator Initialized");
 
             // Read Chart of Accounts from QuickBooks
             List<ChartOfAccount> qbAccounts = CoAReader.QueryAllCoAs();
@@ -103,7 +103,7 @@ namespace QB_CoA_Lib
                 }
             }
 
-            Log.Information("CoAComparator Completed.");
+            Log.Information("ChartOfAccountComparator Completed");
 
             // Merge results: prioritize company accounts
             Dictionary<string, ChartOfAccount> mergedAccountsDict = new Dictionary<string, ChartOfAccount>();
@@ -113,6 +113,12 @@ namespace QB_CoA_Lib
 
             foreach (var acct in companyAccountDict.Values)
                 mergedAccountsDict[acct.Name.Trim().ToLower()] = acct; // Overwrite with company accounts
+
+            List<ChartOfAccount> terms = mergedAccountsDict.Values.ToList();
+            foreach (var term in terms)
+            {
+                Log.Information($"Account {term.Name} is {term.Status}.");
+            }
 
             return mergedAccountsDict.Values.ToList();
         }

--- a/QB_CoA_Test/CoAComparatorTests.cs
+++ b/QB_CoA_Test/CoAComparatorTests.cs
@@ -27,7 +27,7 @@ namespace QB_CoA_Test
             //------------------------------------------------------------------
             const string DEFAULT_ACCOUNT_TYPE = "Expense";
             var initialAccounts = new List<ChartOfAccount>();
-            var rand             = new Random();
+            var rand = new Random();
 
             EnsureLogFileClosed();
             DeleteOldLogFiles();
@@ -36,20 +36,20 @@ namespace QB_CoA_Test
             for (int i = 0; i < 5; i++)
             {
                 string acctNumber = rand.Next(10000, 99999).ToString();
-                string acctName   = $"TestCoA_{Guid.NewGuid():N}".Substring(0, 16);
-                string companyId  = $"CID_{Guid.NewGuid():N}".Substring(0, 8);
+                string acctName = $"TestCoA_{Guid.NewGuid():N}".Substring(0, 16);
+                string companyId = $"CID_{Guid.NewGuid():N}".Substring(0, 8);
 
-                initialAccounts.Add(new ChartOfAccount(DEFAULT_ACCOUNT_TYPE, acctNumber, acctName)
+              initialAccounts.Add(new ChartOfAccount(DEFAULT_ACCOUNT_TYPE, acctNumber, acctName)
                 {
-                    CompanyID = companyId    //  Used as the business-key when comparing
+                    CompanyID = companyId   //  Used as the business-key when comparing
                 });
             }
 
-            List<ChartOfAccount>? firstCompareResult  = null;
+            List<ChartOfAccount>? firstCompareResult = null;
             List<ChartOfAccount>? secondCompareResult = null;
 
             try
-            {
+           {
                 //------------------------------------------------------------------
                 // ②  First compare → every account should be *Added* to QB
                 //------------------------------------------------------------------
@@ -64,13 +64,13 @@ namespace QB_CoA_Test
                 //------------------------------------------------------------------
                 // ③  Mutate list to trigger *Missing* & *Different*
                 //------------------------------------------------------------------
-                var updatedAccounts  = new List<ChartOfAccount>(initialAccounts);
+                var updatedAccounts = new List<ChartOfAccount>(initialAccounts);
 
-                var acctToRemove     = updatedAccounts[0];           // → Missing
-                var acctToRename     = updatedAccounts[1];           // → Different
+                var acctToRemove = updatedAccounts[0];           // → Missing
+                var acctToRename = updatedAccounts[1];           // → Different
 
                 updatedAccounts.Remove(acctToRemove);
-                //acctToRename.Name += "_Mod";
+               //acctToRename.Name += "_Mod";
                 acctToRename.AccountType = "Income";  // Different from original "Expense"
 
 
@@ -130,7 +130,7 @@ namespace QB_CoA_Test
             string logs = File.ReadAllText(logFile);
 
             Assert.Contains("ChartOfAccountComparator Initialized", logs);
-            Assert.Contains("ChartOfAccountComparator Completed",  logs);
+            Assert.Contains("ChartOfAccountComparator Completed", logs);
 
             void AssertLogsFor(IEnumerable<ChartOfAccount>? accts)
             {
@@ -138,7 +138,7 @@ namespace QB_CoA_Test
 
                 foreach (var acct in accts)
                 {
-                    string expected = $"Account {acct.Name} is {acct.Status}.";
+                   string expected = $"Account {acct.Name} is {acct.Status}.";
                     Debug.WriteLine(expected);
                     Assert.Contains(expected, logs);
                 }
@@ -154,7 +154,7 @@ namespace QB_CoA_Test
         private static void DeleteAccount(QuickBooksSession qbSession, string listID)
         {
             IMsgSetRequest req = qbSession.CreateRequestSet();
-            IListDel delRq     = req.AppendListDelRq();
+            IListDel delRq = req.AppendListDelRq();
 
             delRq.ListDelType.SetValue(ENListDelType.ldtAccount);
             delRq.ListID.SetValue(listID);
@@ -163,7 +163,7 @@ namespace QB_CoA_Test
             WalkListDelResponse(rsp, listID);
         }
 
-        private static void WalkListDelResponse(IMsgSetResponse rsp, string listID)
+    private static void WalkListDelResponse(IMsgSetResponse rsp, string listID)
         {
             IResponseList list = rsp.ResponseList;
             if (list == null || list.Count == 0) return;

--- a/QB_CoA_Test/CoAComparatorTests.cs
+++ b/QB_CoA_Test/CoAComparatorTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Serilog;
+using QB_CoA_Lib;               // ChartOfAccount, ChartOfAccountComparator, etc.
+using QBFC16Lib;                // QuickBooks Desktop SDK
+using static QB_CoA_Test.CommonMethods;
+using static QB_CoA_Lib.ChartOfAccount;
+
+namespace QB_CoA_Test
+{
+    /// <summary>
+    /// Tests must run sequentially because QuickBooks Desktop
+    /// allows only one session at a time.
+    /// </summary>
+    [Collection("Sequential Tests")]
+    public class ChartOfAccountComparatorTests
+    {
+        [Fact]
+        public void CompareChartOfAccounts_InMemoryScenario_And_Verify_Logs()
+        {
+            //------------------------------------------------------------------
+            // ①  Build five entirely new in-memory Chart-of-Account objects
+            //------------------------------------------------------------------
+            const string DEFAULT_ACCOUNT_TYPE = "Expense";
+            var initialAccounts = new List<ChartOfAccount>();
+            var rand             = new Random();
+
+            EnsureLogFileClosed();
+            DeleteOldLogFiles();
+            ResetLogger();
+
+            for (int i = 0; i < 5; i++)
+            {
+                string acctNumber = rand.Next(10000, 99999).ToString();
+                string acctName   = $"TestCoA_{Guid.NewGuid():N}".Substring(0, 16);
+                string companyId  = $"CID_{Guid.NewGuid():N}".Substring(0, 8);
+
+                initialAccounts.Add(new ChartOfAccount(DEFAULT_ACCOUNT_TYPE, acctNumber, acctName)
+                {
+                    CompanyID = companyId    //  Used as the business-key when comparing
+                });
+            }
+
+            List<ChartOfAccount>? firstCompareResult  = null;
+            List<ChartOfAccount>? secondCompareResult = null;
+
+            try
+            {
+                //------------------------------------------------------------------
+                // ②  First compare → every account should be *Added* to QB
+                //------------------------------------------------------------------
+                firstCompareResult = CoAComparator.CompareAccounts(initialAccounts);
+
+                foreach (var acct in firstCompareResult
+                                     .Where(a => initialAccounts.Any(x => x.Name.Trim().ToLower() == a.Name.Trim().ToLower())))
+                {
+                    Assert.Equal(ChartOfAccountStatus.Added, acct.Status);
+                }
+
+                //------------------------------------------------------------------
+                // ③  Mutate list to trigger *Missing* & *Different*
+                //------------------------------------------------------------------
+                var updatedAccounts  = new List<ChartOfAccount>(initialAccounts);
+
+                var acctToRemove     = updatedAccounts[0];           // → Missing
+                var acctToRename     = updatedAccounts[1];           // → Different
+
+                updatedAccounts.Remove(acctToRemove);
+                //acctToRename.Name += "_Mod";
+                acctToRename.AccountType = "Income";  // Different from original "Expense"
+
+
+                //------------------------------------------------------------------
+                // ④  Second compare → expect Missing, Different, Unchanged
+                //------------------------------------------------------------------
+                secondCompareResult = CoAComparator.CompareAccounts(updatedAccounts);
+                // !--------change here
+                //var secondDict      = secondCompareResult.ToDictionary(a => a.CompanyID);
+                var secondDict = secondCompareResult.ToDictionary(a => a.Name.Trim().ToLower());
+
+                // Missing
+                Assert.True(secondDict.ContainsKey(acctToRemove.Name.Trim().ToLower()));
+                Assert.Equal(ChartOfAccountStatus.Missing, secondDict[acctToRemove.Name.Trim().ToLower()].Status);
+
+                // Different
+                Assert.True(secondDict.ContainsKey(acctToRename.Name.Trim().ToLower()));
+                Assert.Equal(ChartOfAccountStatus.Different, secondDict[acctToRename.Name.Trim().ToLower()].Status);
+
+                // Unchanged
+                var unaffectedIds = updatedAccounts
+                                    .Select(a => a.Name.Trim().ToLower())
+                                    .Except(new[] { acctToRename.Name.Trim().ToLower() });
+
+                foreach (var id in unaffectedIds)
+                {
+                    Assert.Equal(ChartOfAccountStatus.Unchanged, secondDict[id].Status);
+                }
+            }
+            finally
+            {
+                //------------------------------------------------------------------
+                // ⑤  Clean up – delete everything we added to QuickBooks
+                //------------------------------------------------------------------
+                var allAddedAccounts = firstCompareResult?
+                                       .Where(a => !string.IsNullOrWhiteSpace(a.QB_ID))
+                                       .ToList();
+
+                if (allAddedAccounts is { Count: > 0 })
+                {
+                    using var qbSession = new QuickBooksSession(AppConfig.QB_APP_NAME);
+
+                    foreach (var acct in allAddedAccounts)
+                    {
+                        DeleteAccount(qbSession, acct.QB_ID);
+                    }
+                }
+            }
+
+            //----------------------------------------------------------------------
+            // ⑥  Log verification – make sure our comparator logged what we expect
+            //----------------------------------------------------------------------
+            EnsureLogFileClosed();
+            string logFile = GetLatestLogFile();
+            EnsureLogFileExists(logFile);
+
+            string logs = File.ReadAllText(logFile);
+
+            Assert.Contains("ChartOfAccountComparator Initialized", logs);
+            Assert.Contains("ChartOfAccountComparator Completed",  logs);
+
+            void AssertLogsFor(IEnumerable<ChartOfAccount>? accts)
+            {
+                if (accts == null) return;
+
+                foreach (var acct in accts)
+                {
+                    string expected = $"Account {acct.Name} is {acct.Status}.";
+                    Debug.WriteLine(expected);
+                    Assert.Contains(expected, logs);
+                }
+            }
+
+            AssertLogsFor(firstCompareResult);
+            AssertLogsFor(secondCompareResult);
+        }
+
+        // ---------------------------------------------------------------------
+        // QuickBooks-specific helper to delete an Account list element cleanly
+        // ---------------------------------------------------------------------
+        private static void DeleteAccount(QuickBooksSession qbSession, string listID)
+        {
+            IMsgSetRequest req = qbSession.CreateRequestSet();
+            IListDel delRq     = req.AppendListDelRq();
+
+            delRq.ListDelType.SetValue(ENListDelType.ldtAccount);
+            delRq.ListID.SetValue(listID);
+
+            IMsgSetResponse rsp = qbSession.SendRequest(req);
+            WalkListDelResponse(rsp, listID);
+        }
+
+        private static void WalkListDelResponse(IMsgSetResponse rsp, string listID)
+        {
+            IResponseList list = rsp.ResponseList;
+            if (list == null || list.Count == 0) return;
+
+            IResponse resp = list.GetAt(0);
+            if (resp.StatusCode != 0)
+            {
+                Debug.WriteLine($"Error deleting account (ListID={listID}): {resp.StatusMessage}");
+            }
+        }
+    }
+}

--- a/QB_CoA_Test/CoAComparatorTests.cs
+++ b/QB_CoA_Test/CoAComparatorTests.cs
@@ -28,7 +28,7 @@ namespace QB_CoA_Test
             //------------------------------------------------------------------
             const string DEFAULT_ACCOUNT_TYPE = "Expense";
             var initialAccounts = new List<ChartOfAccount>();
-            var rand            = new Random();
+            var rand = new Random();
 
             EnsureLogFileClosed();
             DeleteOldLogFiles();
@@ -37,20 +37,20 @@ namespace QB_CoA_Test
             for (int i = 0; i < 5; i++)
             {
                 string acctNumber = rand.Next(10000, 99999).ToString();
-                string acctName   = $"TestCoA_{Guid.NewGuid():N}".Substring(0, 16);
-                string companyId  = $"CID_{Guid.NewGuid():N}".Substring(0, 8);
+                string acctName = $"TestCoA_{Guid.NewGuid():N}".Substring(0, 16);
+                string companyId = $"CID_{Guid.NewGuid():N}".Substring(0, 8);
 
-              initialAccounts.Add(new ChartOfAccount(DEFAULT_ACCOUNT_TYPE, acctNumber, acctName)
+                initialAccounts.Add(new ChartOfAccount(DEFAULT_ACCOUNT_TYPE, acctNumber, acctName)
                 {
                     CompanyID = companyId   //  Used as the business-key when comparing
                 });
             }
 
-            List<ChartOfAccount>? firstCompareResult  = null;
+            List<ChartOfAccount>? firstCompareResult = null;
             List<ChartOfAccount>? secondCompareResult = null;
 
             try
-           {
+            {
                 //------------------------------------------------------------------
                 // ②  First compare → every account should be *Added* to QB
                 //------------------------------------------------------------------
@@ -69,8 +69,8 @@ namespace QB_CoA_Test
                 //------------------------------------------------------------------
                 var updatedAccounts = new List<ChartOfAccount>(initialAccounts);
 
-                var acctToRemove    = updatedAccounts[0];           // → Missing
-                var acctToRename    = updatedAccounts[1];           // → Different
+                var acctToRemove = updatedAccounts[0];           // → Missing
+                var acctToRename = updatedAccounts[1];           // → Different
 
                 updatedAccounts.Remove(acctToRemove);
                 //acctToRename.Name += "_Mod";
@@ -166,7 +166,7 @@ namespace QB_CoA_Test
             WalkListDelResponse(rsp, listID);
         }
 
-    private static void WalkListDelResponse(IMsgSetResponse rsp, string listID)
+        private static void WalkListDelResponse(IMsgSetResponse rsp, string listID)
         {
             IResponseList list = rsp.ResponseList;
             if (list == null || list.Count == 0) return;


### PR DESCRIPTION
Hello Sir,

The Comparator test cases have passed successfully. The minor correction is that, as per our previous discussion, The chart of accounts doesnt have company.id and we thought of using desc as our company id but due to various reasons like comparator and adder and reader giving errors if we use desc as our company id. In our previous class, we've discussed that the unique key to use in the dict would be company name as there can only be one company name. So i've ported all the ".company id" terms used in the comparator test file to ".name.trim().toLower(") and just ran it once and all the test cases in comparator have passed. So please accept this request to merge.

![Capture](https://github.com/user-attachments/assets/96757e18-9ef6-4c7f-8f72-982856feb0c0)
